### PR TITLE
Fix cache invalidation for modified tags

### DIFF
--- a/src/TagDependencyTrait.php
+++ b/src/TagDependencyTrait.php
@@ -38,6 +38,7 @@ trait TagDependencyTrait
 
     /**
      * Returns object tag name including it's id
+     * @param array Changed fields from Update Event
      * @return string tag name
      */
     public function objectTag($oldfields)
@@ -60,6 +61,7 @@ trait TagDependencyTrait
 
     /**
      * Returns composite tags name including fields
+     * @param array Changed fields from Update Event
      * @return array tag names
      */
     public function objectCompositeTag($oldfields)
@@ -181,6 +183,7 @@ trait TagDependencyTrait
 
     /**
      * Invalidate model tags.
+     * @param yii\db\AfterSaveEvent when called as an event handler.
      * @return bool
      */
     public function invalidateTags($event = null)

--- a/src/TagDependencyTrait.php
+++ b/src/TagDependencyTrait.php
@@ -44,7 +44,7 @@ trait TagDependencyTrait
     public function objectTag($oldFields = [])
     {
         /** @var \yii\db\ActiveRecord $this */
-        $primaryKey;
+        $primaryKey = null;
         if (count($this->primaryKey()) === 1)
         {
             $key = $this->primaryKey()[0];
@@ -184,24 +184,25 @@ trait TagDependencyTrait
 
     /**
      * Invalidate model tags.
-     * @param yii\db\AfterSaveEvent $event when called as an event handler.
+     * @param yii\db\AfterSaveEvent|null $event when called as an event handler.
      * @return bool
      */
     public function invalidateTags($event = null)
     {
         /** @var TagDependencyTrait $this */
+        $oldFields = $event !== null && $event->name === ActiveRecord::EVENT_AFTER_UPDATE ? $event->changedAttributes : [];
         \yii\caching\TagDependency::invalidate(
             $this->getTagDependencyCacheComponent(),
             [
                 static::commonTag(),
-                $this->objectTag($event !== null && $event->name === ActiveRecord::EVENT_AFTER_UPDATE ? $event->changedAttributes : [])
+                $this->objectTag($oldFields)
             ]
         );
 
         if (!empty($this->cacheCompositeTagFields())) {
             \yii\caching\TagDependency::invalidate(
                 $this->getTagDependencyCacheComponent(),
-                $this->objectCompositeTag($event !== null && $event->name === ActiveRecord::EVENT_AFTER_UPDATE ? $event->changedAttributes : [])
+                $this->objectCompositeTag($oldFields)
             );
         }
 

--- a/src/TagDependencyTrait.php
+++ b/src/TagDependencyTrait.php
@@ -40,7 +40,7 @@ trait TagDependencyTrait
      * Returns object tag name including it's id
      * @return string tag name
      */
-    public function objectTag()
+    public function objectTag($oldfields)
     {
         /** @var \yii\db\ActiveRecord $this */
         $primary_key;
@@ -48,9 +48,7 @@ trait TagDependencyTrait
         {
             $key = $this->primaryKey()[0];
             $primary_key = isset($oldfields[$key]) ? $oldfields[$key] : $this->$key;
-        }
-        else
-        {
+        } else {
             $primary_key = [];
             foreach ($this->primaryKey() as $key)
             {
@@ -64,7 +62,7 @@ trait TagDependencyTrait
      * Returns composite tags name including fields
      * @return array tag names
      */
-    public function objectCompositeTag()
+    public function objectCompositeTag($oldfields)
     {
         /** @var \yii\db\ActiveRecord|TagDependencyTrait $this */
         $cacheFields = $this->cacheCompositeTagFields();
@@ -86,8 +84,7 @@ trait TagDependencyTrait
 
             $tags[] = NamingHelper::getCompositeTag($this->className(), $tag);
 
-            if ($changed)
-            {
+            if ($changed) {
                 $tag = [];
                 foreach ($tagFields as $tagField) {
                     $tag[$tagField] = isset($oldfields[$tagField]) ? $oldfields[$tagField] : $this->$tagField;
@@ -186,21 +183,21 @@ trait TagDependencyTrait
      * Invalidate model tags.
      * @return bool
      */
-    public function invalidateTags($event)
+    public function invalidateTags($event = null)
     {
         /** @var TagDependencyTrait $this */
         \yii\caching\TagDependency::invalidate(
             $this->getTagDependencyCacheComponent(),
             [
                 static::commonTag(),
-                $this->objectTag($event->name == ActiveRecord::EVENT_AFTER_UPDATE ? $event->changedAttributes : [])
+                $this->objectTag($event != null && $event->name == ActiveRecord::EVENT_AFTER_UPDATE ? $event->changedAttributes : [])
             ]
         );
 
         if (!empty($this->cacheCompositeTagFields())) {
             \yii\caching\TagDependency::invalidate(
                 $this->getTagDependencyCacheComponent(),
-                $this->objectCompositeTag($event->name == ActiveRecord::EVENT_AFTER_UPDATE ? $event->changedAttributes : [])
+                $this->objectCompositeTag($event != null && $event->name == ActiveRecord::EVENT_AFTER_UPDATE ? $event->changedAttributes : [])
             );
         }
 

--- a/src/TagDependencyTrait.php
+++ b/src/TagDependencyTrait.php
@@ -73,6 +73,7 @@ trait TagDependencyTrait
             return [];
         }
 
+        $cacheFields = (is_array($cacheFields) && !empty($cacheFields) && is_array($cacheFields[0])) ? $cacheFields : [$cacheFields];
         $tags = [];
 
         foreach ($cacheFields as $tagFields) {

--- a/src/TagDependencyTrait.php
+++ b/src/TagDependencyTrait.php
@@ -41,7 +41,7 @@ trait TagDependencyTrait
      * @param array Changed fields from Update Event
      * @return string tag name
      */
-    public function objectTag($oldfields)
+    public function objectTag($oldfields = [])
     {
         /** @var \yii\db\ActiveRecord $this */
         $primary_key;
@@ -64,7 +64,7 @@ trait TagDependencyTrait
      * @param array Changed fields from Update Event
      * @return array tag names
      */
-    public function objectCompositeTag($oldfields)
+    public function objectCompositeTag($oldfields = [])
     {
         /** @var \yii\db\ActiveRecord|TagDependencyTrait $this */
         $cacheFields = $this->cacheCompositeTagFields();

--- a/src/TagDependencyTrait.php
+++ b/src/TagDependencyTrait.php
@@ -38,33 +38,33 @@ trait TagDependencyTrait
 
     /**
      * Returns object tag name including it's id
-     * @param array Changed fields from Update Event
+     * @param array $oldFields Changed fields from Update Event
      * @return string tag name
      */
-    public function objectTag($oldfields = [])
+    public function objectTag($oldFields = [])
     {
         /** @var \yii\db\ActiveRecord $this */
-        $primary_key;
-        if (count($this->primaryKey()) == 1)
+        $primaryKey;
+        if (count($this->primaryKey()) === 1)
         {
             $key = $this->primaryKey()[0];
-            $primary_key = isset($oldfields[$key]) ? $oldfields[$key] : $this->$key;
+            $primaryKey = isset($oldFields[$key]) ? $oldFields[$key] : $this->$key;
         } else {
-            $primary_key = [];
+            $primaryKey = [];
             foreach ($this->primaryKey() as $key)
             {
-                $primary_key[$key] = isset($oldfields[$key]) ? $oldfields[$key] : $this->$key;
+                $primaryKey[$key] = isset($oldFields[$key]) ? $oldFields[$key] : $this->$key;
             }
         }
-        return NamingHelper::getObjectTag($this->className(), $primary_key);
+        return NamingHelper::getObjectTag($this->className(), $primaryKey);
     }
 
     /**
      * Returns composite tags name including fields
-     * @param array Changed fields from Update Event
+     * @param array $oldFields Changed fields from Update Event
      * @return array tag names
      */
-    public function objectCompositeTag($oldfields = [])
+    public function objectCompositeTag($oldFields = [])
     {
         /** @var \yii\db\ActiveRecord|TagDependencyTrait $this */
         $cacheFields = $this->cacheCompositeTagFields();
@@ -82,7 +82,7 @@ trait TagDependencyTrait
 
             foreach ($tagFields as $tagField) {
                 $tag[$tagField] = $this->$tagField;
-                $changed |= isset($oldfields[$tagField]);
+                $changed |= isset($oldFields[$tagField]);
             }
 
             $tags[] = NamingHelper::getCompositeTag($this->className(), $tag);
@@ -90,7 +90,7 @@ trait TagDependencyTrait
             if ($changed) {
                 $tag = [];
                 foreach ($tagFields as $tagField) {
-                    $tag[$tagField] = isset($oldfields[$tagField]) ? $oldfields[$tagField] : $this->$tagField;
+                    $tag[$tagField] = isset($oldFields[$tagField]) ? $oldFields[$tagField] : $this->$tagField;
                 }
                 $tags[] = NamingHelper::getCompositeTag($this->className(), $tag);
             }
@@ -184,7 +184,7 @@ trait TagDependencyTrait
 
     /**
      * Invalidate model tags.
-     * @param yii\db\AfterSaveEvent when called as an event handler.
+     * @param yii\db\AfterSaveEvent $event when called as an event handler.
      * @return bool
      */
     public function invalidateTags($event = null)
@@ -194,14 +194,14 @@ trait TagDependencyTrait
             $this->getTagDependencyCacheComponent(),
             [
                 static::commonTag(),
-                $this->objectTag($event != null && $event->name == ActiveRecord::EVENT_AFTER_UPDATE ? $event->changedAttributes : [])
+                $this->objectTag($event !== null && $event->name === ActiveRecord::EVENT_AFTER_UPDATE ? $event->changedAttributes : [])
             ]
         );
 
         if (!empty($this->cacheCompositeTagFields())) {
             \yii\caching\TagDependency::invalidate(
                 $this->getTagDependencyCacheComponent(),
-                $this->objectCompositeTag($event != null && $event->name == ActiveRecord::EVENT_AFTER_UPDATE ? $event->changedAttributes : [])
+                $this->objectCompositeTag($event !== null && $event->name === ActiveRecord::EVENT_AFTER_UPDATE ? $event->changedAttributes : [])
             );
         }
 


### PR DESCRIPTION
The current implementation only invalidates tags using the current (new) attribute values used by the tag. Caches that use the old value retain the entities.

The fix basically tracks if the primary key attributes, or the composite tag attributes change, and uses the old value for invalidating the cache. In the case of composite keys it also invalidates caches using the new attribute values.

With the primary key the assumption is that there is no need to flush the cache for the new value, since this should be unique.

I didn't have time to create unit tests using your framework, but basically you create an entity, get it using the cache, modify the primary key, or the one of the composite tagged attributes and save. You can still get the outdated models from the caches using the old values...

There is still a problem related to deleting. If you modify the record's attributes and then delete, it can't detect the old values, and they're no longer available since yii nulls $_oldattributes. This is a pretty niche case though.
