### PR TITLE
empty now supports expressions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
+        "php": ">=5.5.0",
         "yiisoft/yii2": "~2.0.6"
     },
     "require-dev": {


### PR DESCRIPTION
PHP 5.5.0   empty() теперь поддерживает выражения, а не только переменные.
